### PR TITLE
Bugfix: Replace PanelManager with WorkspaceManager

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ define(function (require, exports, module) {
         DocumentManager = brackets.getModule("document/DocumentManager"),
         KeyBindingManager = brackets.getModule('command/KeyBindingManager'),
         FileUtils = brackets.getModule("file/FileUtils"),
-        PanelManager = brackets.getModule("view/PanelManager"),
+        WorkspaceManager = brackets.getModule("view/WorkspaceManager"),
         Dialogs = brackets.getModule("widgets/Dialogs"),
         nodeConnection = new NodeConnection(),
         domainPath = ExtensionUtils.getModulePath(module) + "domain",

--- a/results-panel.js
+++ b/results-panel.js
@@ -3,7 +3,7 @@
 
 define(function (require, exports, module) {
     "use strict";
-    var PanelManager = brackets.getModule("view/PanelManager"),
+    var WorkspaceManager = brackets.getModule("view/WorkspaceManager"),
         DocumentManager = brackets.getModule("document/DocumentManager"),
         EditorManager = brackets.getModule("editor/EditorManager"),
         decorate = require("decorate");
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
         panelHTML = require('text!results-panel.html'),
         panelIsVisible = false;
 
-    panel = PanelManager.createBottomPanel("brackets-builder-panel", $(panelHTML), 100);
+    panel = WorkspaceManager.createBottomPanel("brackets-builder-panel", $(panelHTML), 100);
     $('#builder-panel .close').on('click', function () {
         panel.hide();
     });


### PR DESCRIPTION
- As of Brackets 1.12 (2018-02-05), PanelManager is no longer supported.
- As a result, brackets-integrated-development fails to load in 1.12.
- This PR replaces PanelManager with the newer WorkspaceManager.

